### PR TITLE
修复form初始值

### DIFF
--- a/packages/vbenComponents/src/form/src/Form.vue
+++ b/packages/vbenComponents/src/form/src/Form.vue
@@ -34,7 +34,7 @@ const setProps = (prop: Partial<VbenFormProps>) => {
     ...unref(innerProps),
   }
 }
-const fieldValue = ref({})
+const fieldValue = ref(attrs.model)
 watch(
   () => attrs.model,
   () => {


### PR DESCRIPTION
还删除了 table.vue 中的titleClass 这完全是一个无用的属性且还影响了暗黑模式对于颜色的转换