### PR TITLE
侧边栏和顶栏颜色

### DIFF
--- a/packages/layouts/src/left-menu.vue
+++ b/packages/layouts/src/left-menu.vue
@@ -21,29 +21,49 @@ const { isSidebarDark } = useAppTheme()
 </script>
 <template>
   <VbenLayout has-sider class="h-full">
-    <VbenLayoutSider
-      v-if="getShowMenu"
-      :show-trigger="getShowCenterTrigger"
-      bordered
-      :collapsed-width="sidebar.collapsedWidth"
-      :width="sidebar.width"
-      collapse-mode="width"
-      :collapsed="getCollapsed"
-      @update:collapsed="toggleCollapse"
-      :inverted="!!isSidebarDark"
+    <VbenConfig
+      :themeOverrides="{
+        common: {
+          primaryColor: '#0960bd',
+          invertedColor: '#0960bd',
+        },
+      }"
     >
-      <slot name="sider">
-        <div class="static h-full">
-          <SiderDragBar
-            :mix="sidebar.mixSidebarWidth"
-            :width="sidebar.width"
-            :fn="setSiderWidth"
-          /><LayoutMenu />
-        </div>
-      </slot>
-    </VbenLayoutSider>
+      <VbenLayoutSider
+        v-if="getShowMenu"
+        :show-trigger="getShowCenterTrigger"
+        bordered
+        :collapsed-width="sidebar.collapsedWidth"
+        :width="sidebar.width"
+        collapse-mode="width"
+        :collapsed="getCollapsed"
+        @update:collapsed="toggleCollapse"
+        :inverted="true"
+      >
+        <slot name="sider">
+          <div class="static h-full">
+            <SiderDragBar
+              :mix="sidebar.mixSidebarWidth"
+              :width="sidebar.width"
+              :fn="setSiderWidth"
+            /><LayoutMenu />
+          </div>
+        </slot>
+      </VbenLayoutSider>
+    </VbenConfig>
     <VbenLayout>
-      <slot name="header"><LayoutHeader ref="headerRef" /></slot>
+      <slot name="header">
+        <VbenConfig
+          :themeOverrides="{
+            common: {
+              primaryColor: '#0960bd',
+              invertedColor: '#0960bd',
+            },
+          }"
+        >
+          <LayoutHeader ref="headerRef" />
+        </VbenConfig>
+      </slot>
       <VbenLayout :content-style="contentStyle">
         <VbenLayoutContent :content-style="mainStyle" ref="contentRef">
           <LayoutMain>


### PR DESCRIPTION
如下图，通过给layout包一层config-provider的方式可以设置颜色。
设置背景色发现采用invertedColor的效果较好。
![image](https://github.com/vbenjs/vben3/assets/90845831/eb66833a-195a-49c3-a883-866e06026b3d)

@aonoa 
