### PR TITLE
feat(ci): add release-tag

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,22 @@
+name: Create Release Tag
+
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Release for Tag
+        id: release_tag
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: 'true'
+          body: |
+            > Please refer to [CHANGELOG.md](https://github.com/vbenjs/vben3/blob/master/CHANGELOG.md) for details.


### PR DESCRIPTION
使用此 ci 工具，推送带tag的commit时候，可以自动生成release版本.

commit信息如何携带tag参考 https://docs.github.com/zh/desktop/managing-commits/managing-tags-in-github-desktop