### PR TITLE
解决countdown-input组件无法显示countdown按钮问题

### DIFF
--- a/packages/components/src/countdown-input/index.vue
+++ b/packages/components/src/countdown-input/index.vue
@@ -38,7 +38,7 @@ const slotKeys = computed(() => {
 
 <template>
   <vben-input v-bind="attrs" :class="bem()" :size="size" :value="state">
-    <template #addonAfter>
+    <template #suffix> <!--NaiveUI的后缀slot写法不是addonAfter是suffx-->
       <CountButton
         :size="size"
         :count="count"
@@ -54,6 +54,9 @@ const slotKeys = computed(() => {
 
 <style lang="less">
 .count-down-input {
+  .n-input-wrapper{
+    padding-right:0px; //NaiveUI有Count-down按钮时不需要右边距
+  }
   .ant-input-group-addon {
     padding-right: 0;
     background-color: transparent;


### PR DESCRIPTION
### `General`

> ✏️ 在登录页面有一个验证码登录，如下但是却没有发送验证码的按钮

<img width="436" alt="截屏2024-05-21 14 40 00" src="https://github.com/vbenjs/vben3/assets/155605544/b7031003-3405-4f4a-afbc-1d1b167346a8">

经查看是使用了NaiveUI后样式没有更改，于是进行了Fix，完成后的样子如下：

<img width="443" alt="截屏2024-05-21 14 40 13" src="https://github.com/vbenjs/vben3/assets/155605544/52a1384a-5472-44c8-8e1c-e696e67d8fbc">


- [ ] Pull request template structure not broken

### `Type`

> ℹ️ What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### `Checklist`

> ℹ️ Check all checkboxes - this will indicate that you have done everything in accordance with the rules in [CONTRIBUTING](contributing.md).

> 👉 _Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [x] Is the code format correct
- [x] Is the git submission information standard?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
